### PR TITLE
Fix CoinGecko adapter configuration

### DIFF
--- a/app/services/services_config.rb
+++ b/app/services/services_config.rb
@@ -19,7 +19,7 @@ module ServicesConfig
             timeout: ENV.fetch('KUCOIN_API_TIMEOUT', common_config[:timeout])
           },
           coin_gecko: {
-            api_url: ENV.fetch('COINGECKO_API_URL', 'https://api.coingecko.com/api/v3'),
+            base_url: ENV.fetch('COINGECKO_API_URL', 'https://api.coingecko.com/api/v3'),
             timeout: ENV.fetch('COINGECKO_API_TIMEOUT', common_config[:timeout])
           },
           binance: {


### PR DESCRIPTION
## Summary
- update `ServicesConfig` so CoinGecko adapter uses `base_url`

## Testing
- `bundle exec rspec` *(fails: ActiveRecord::ConnectionNotEstablished)*

------
https://chatgpt.com/codex/tasks/task_e_68567b52bd248333a261e5e76a8c0d7c