### PR TITLE
Fix failing specs and add TwitterError

### DIFF
--- a/lib/errors/twitter_error.rb
+++ b/lib/errors/twitter_error.rb
@@ -1,0 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
+module Errors
+  class TwitterError < StandardError; end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,13 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
+# Provide defaults for secrets used in tests
+ENV['DEVISE_JWT_SECRET_KEY'] ||= 'test_secret'
+ENV['BINANCE_API_KEY'] ||= 'key'
+ENV['BINANCE_API_SECRET'] ||= 'secret'
+ENV['KUCOIN_API_KEY'] ||= 'key'
+ENV['KUCOIN_API_SECRET'] ||= 'secret'
+ENV['KUCOIN_API_PASSPHRASE'] ||= 'passphrase'
 require_relative '../config/environment'
 
 # Prevent database truncation if the environment is production

--- a/spec/services/market_data/fetcher_spec.rb
+++ b/spec/services/market_data/fetcher_spec.rb
@@ -83,6 +83,9 @@ RSpec.describe MarketData::Fetcher do
       common_config: { log_level: 'INFO', timeout: 30 },
       market_data_config: market_data_config
     )
+
+    # Reconfigure class with stubbed config after stubbing ServicesConfig
+    described_class.configure(market_data_config)
   end
 
   describe 'initialization' do

--- a/spec/services/trading/adapters/binance_spec.rb
+++ b/spec/services/trading/adapters/binance_spec.rb
@@ -6,6 +6,11 @@ require 'rails_helper'
 RSpec.describe Trading::Adapters::Binance do
   subject(:adapter) { described_class.new('BTCUSDT', action, 0.5, price) }
 
+  before do
+    stub_const('Trading::Adapters::Binance::API_KEY', 'key')
+    stub_const('Trading::Adapters::Binance::API_SECRET', 'secret')
+  end
+
   let(:action) { 'BUY' }
   let(:price) { nil } # Market order
 

--- a/spec/services/trading/adapters/ku_coin_spec.rb
+++ b/spec/services/trading/adapters/ku_coin_spec.rb
@@ -6,6 +6,12 @@ require 'rails_helper'
 RSpec.describe Trading::Adapters::KuCoin do
   subject(:adapter) { described_class.new('BTC-USDT', action, 0.5, price) }
 
+  before do
+    stub_const('Trading::Adapters::KuCoin::API_KEY', 'key')
+    stub_const('Trading::Adapters::KuCoin::API_SECRET', 'secret')
+    stub_const('Trading::Adapters::KuCoin::API_PASSPHRASE', 'passphrase')
+  end
+
   let(:action) { 'BUY' }
   let(:price) { nil } # Market order
 


### PR DESCRIPTION
## Summary
- set default env vars in test helper to satisfy JWT and adapter configs
- ensure MarketData::Fetcher reconfigures when stubbing config
- stub API credentials in trading adapter specs
- add missing `Errors::TwitterError`
- run RuboCop autocorrect

## Testing
- `bundle exec rubocop`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_68567e89b58083339668b742333e4a59