### PR TITLE
Fix sign-out spec jti check

### DIFF
--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -25,11 +25,13 @@ RSpec.describe 'User Authentication', type: :request do
     end
 
     it 'logs out the user and revokes the token' do
+      old_jti = user.jti
+
       delete '/users/sign_out', headers: { 'Authorization' => "Bearer #{token}" }
 
       expect(response).to have_http_status(:no_content)
       user.reload
-      expect(user.jti).not_to eq(token) # Ensure JTI changes after logout
+      expect(user.jti).not_to eq(old_jti) # Ensure JTI changes after logout
     end
   end
 end


### PR DESCRIPTION
## Summary
- update jti expectation in `authentication_spec`

## Testing
- `bundle exec rspec spec/requests/authentication_spec.rb --format doc --no-color` *(fails: PG::ConnectionBad connection refused)*
- `bundle exec rails db:test:prepare` *(fails: NameError: uninitialized constant GraphiQL)*


------
https://chatgpt.com/codex/tasks/task_e_685682cd0c4483339c42a9b141597d87